### PR TITLE
build(docker): add docker build system for palladium core

### DIFF
--- a/docker-build/.dockerignore
+++ b/docker-build/.dockerignore
@@ -1,0 +1,74 @@
+# Build outputs
+out/
+*.o
+*.a
+*.so
+*.dylib
+*.exe
+
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# Documentation
+*.md
+doc/
+README*
+
+# CI/CD
+.github/
+.travis.yml
+.appveyor.yml
+.cirrus.yml
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Temporary files
+*.tmp
+*.temp
+*.log
+
+# Test files
+test/
+src/test/
+src/bench/
+
+# Qt files (if not needed for headless build)
+src/qt/
+
+# Dependencies cache (will be rebuilt)
+depends/built/
+depends/work/
+depends/sources/
+
+# Autotools generated files
+autom4te.cache/
+config.log
+config.status
+configure
+Makefile
+Makefile.in
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+
+# Backup files
+*.bak
+*.backup

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libtool \
+    autotools-dev \
+    automake \
+    autoconf \
+    pkg-config \
+    bsdmainutils \
+    python3 \
+    curl \
+    ca-certificates \
+    git \
+    unzip \
+    zip \
+    file \
+    rsync \
+    gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+CMD ["/bin/bash"]

--- a/docker-build/README.md
+++ b/docker-build/README.md
@@ -1,0 +1,34 @@
+# Docker Build System for Palladium Core
+
+Docker-based build system for creating Palladium Core binaries.
+
+## Quick Start
+
+```bash
+cd docker-build
+chmod +x build-linux-x86_64.sh
+./build-linux-x86_64.sh
+```
+
+Binaries will be available in the `out/` directory.
+
+## Prerequisites
+
+- Docker installed and running
+
+## Produced Binaries
+
+- `palladiumd`: Main daemon
+- `palladium-cli`: Command-line client
+- `palladium-tx`: Transaction utility
+- `palladium-wallet`: Wallet utility
+- `palladium-qt`: GUI (if available)
+
+## Troubleshooting
+
+**Permission errors:** Use `sudo ./build-linux-x86_64.sh`
+
+**Build failed:** Run interactive container for debugging:
+```bash
+docker run --rm -it -v "$(pwd)":/src palladium-builder:ubuntu20.04 bash
+```

--- a/docker-build/build-linux-x86_64.sh
+++ b/docker-build/build-linux-x86_64.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_NAME="palladium-builder:ubuntu20.04"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+OUT_DIR="${SCRIPT_DIR}/out"
+HOST="x86_64-pc-linux-gnu"
+
+if ! docker image inspect "$IMAGE_NAME" >/dev/null 2>&1; then
+  docker build -t "$IMAGE_NAME" -f "${SCRIPT_DIR}/Dockerfile" "${SCRIPT_DIR}"
+fi
+
+mkdir -p "$OUT_DIR"
+
+docker run --rm \
+  -v "${REPO_DIR}":/src \
+  -v "${OUT_DIR}":/out \
+  "$IMAGE_NAME" \
+  bash -c "
+    set -euo pipefail
+    cd /src
+    cd depends && make HOST=${HOST} -j\$(nproc) && cd ..
+    [[ -x ./autogen.sh ]] && ./autogen.sh
+    ./configure --prefix=\$PWD/depends/${HOST} \
+                --enable-glibc-back-compat \
+                --enable-reduce-exports \
+                LDFLAGS='-static-libstdc++'
+    make -j\$(nproc)
+    for bin in src/palladiumd src/palladium-cli src/palladium-tx src/palladium-wallet src/qt/palladium-qt; do
+      [[ -f \"\$bin\" ]] && install -m 0755 \"\$bin\" /out/
+    done
+  "
+
+echo "[*] x86_64 binaries copied to ${OUT_DIR}"


### PR DESCRIPTION
Add Dockerfile, build script, README and .dockerignore to create a reproducible build environment for Palladium Core binaries. The system builds x86_64 Linux binaries with all required dependencies and outputs them to the out/ directory.

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Palladium Core user experience or Palladium Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Palladium Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Palladium Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
